### PR TITLE
Controllers now allow the number of advertised racks

### DIFF
--- a/src/main/java/com/ldtteam/storageracks/EventManager.java
+++ b/src/main/java/com/ldtteam/storageracks/EventManager.java
@@ -59,7 +59,7 @@ public class EventManager
         else
         {
             final ControllerBlock controller = (ControllerBlock) event.getEntity().level.getBlockState(result).getBlock();
-            if (posSet.size() > controller.getTier() * 20)
+            if (posSet.size() - 1 > controller.getTier() * 20)
             {
                 event.getEntity().sendMessage(new TranslationTextComponent("gui.storageracks.limitreached"), event.getEntity().getUUID());
                 event.setCanceled(true);


### PR DESCRIPTION
Previously, controllers would not allow players to place the final rack they should be able to - i.e. for a stone controller, on placing the 20th rack, an error would display that they're over the capacity.

This is because of the logic in EventManager that calculates how many racks the player has placed down already. It stores this in a HashSet called `posSet`, but the HashSet also includes the controller in the Set, which explains why the max is offset by 1.

This feature accounts for the controller by subtracting 1 from `posSet.size()`. So in the above example:

```
Player is placing down their 20th rack
posSet.size() will return 21
stone controller tier is 1

21 - 1 > 1 * 20
20 > 20
false

So no error will be displayed. If they tried to place their 21st rack:

22 - 1 > 1 * 20
21 > 20
true

So an error would display.
```

---

This fixes #14.